### PR TITLE
NLPUC: Hooke-Jeeves-java: Two commits:

### DIFF
--- a/nlp-unconstrained-core/hooke-jeeves/java/src/main/java/optimization/nonlinear/unconstrained/core/Hooke.java
+++ b/nlp-unconstrained-core/hooke-jeeves/java/src/main/java/optimization/nonlinear/unconstrained/core/Hooke.java
@@ -69,7 +69,8 @@ public class Hooke {
      * <br />
      * <br />Given a point, look for a better one nearby, one coord at a time.
      *
-     * @param delta     The delta between prevBest and point.
+     * @param delta     The delta between <code>prevBest</code>
+     *                  and <code>point</code>.
      * @param point     The coordinate from where to begin.
      * @param prevBest  The previous best-valued coordinate.
      * @param nVars     The number of variables.

--- a/nlp-unconstrained-core/hooke-jeeves/java/src/main/java/optimization/nonlinear/unconstrained/core/Hooke.java
+++ b/nlp-unconstrained-core/hooke-jeeves/java/src/main/java/optimization/nonlinear/unconstrained/core/Hooke.java
@@ -69,11 +69,11 @@ public class Hooke {
      * <br />
      * <br />Given a point, look for a better one nearby, one coord at a time.
      *
-     * @param delta        The delta between prevBest and point.
-     * @param point        The coordinate from where to begin.
-     * @param prevBest     The previous best-valued coordinate.
-     * @param nVars        The number of variables.
-     * @param objFunClsObj The class object containing objective function.
+     * @param delta     The delta between prevBest and point.
+     * @param point     The coordinate from where to begin.
+     * @param prevBest  The previous best-valued coordinate.
+     * @param nVars     The number of variables.
+     * @param objFunCls The class in which the objective function is defined.
      *
      * @return The objective function value at a nearby.
      */
@@ -81,7 +81,7 @@ public class Hooke {
                               final double[] point,
                               final double prevBest,
                               final int nVars,
-                              final Object objFunClsObj) {
+                              final Class objFunCls) {
 
         double minF;
         double[] z = new double[VARS];
@@ -98,9 +98,9 @@ public class Hooke {
         for (i = 0; i < nVars; i++) {
             z[i] = point[i] + delta[i];
 
-            if (objFunClsObj instanceof Rosenbrock) {
+            if (objFunCls.equals(Rosenbrock.class)) {
                 fTmp = Rosenbrock.f(z, nVars);
-            } else if (objFunClsObj instanceof Woods) {
+            } else if (objFunCls.equals(Woods.class)) {
                 fTmp = Woods.f(z, nVars);
             } else {
                 fTmp = 0;
@@ -112,9 +112,9 @@ public class Hooke {
                 delta[i] = 0.0 - delta[i];
                 z[i]     = point[i] + delta[i];
 
-                if (objFunClsObj instanceof Rosenbrock) {
+                if (objFunCls.equals(Rosenbrock.class)) {
                     fTmp = Rosenbrock.f(z, nVars);
-                } else if (objFunClsObj instanceof Woods) {
+                } else if (objFunCls.equals(Woods.class)) {
                     fTmp = Woods.f(z, nVars);
                 } else {
                     fTmp = 0;
@@ -140,13 +140,13 @@ public class Hooke {
      * <br />
      * <br />The hooke subroutine itself.
      *
-     * @param nVars        The number of variables.
-     * @param startPt      The starting point coordinates.
-     * @param endPt        The ending point coordinates.
-     * @param rho          The rho value.
-     * @param epsilon      The epsilon value.
-     * @param iterMax      The maximum number of iterations.
-     * @param objFunClsObj The class object containing objective function.
+     * @param nVars     The number of variables.
+     * @param startPt   The starting point coordinates.
+     * @param endPt     The ending point coordinates.
+     * @param rho       The rho value.
+     * @param epsilon   The epsilon value.
+     * @param iterMax   The maximum number of iterations.
+     * @param objFunCls The class in which the objective function is defined.
      *
      * @return The number of iterations used to find the local minimum.
      */
@@ -156,7 +156,7 @@ public class Hooke {
                      final double rho,
                      final double epsilon,
                      final int iterMax,
-                     final Object objFunClsObj) {
+                     final Class objFunCls) {
 
         int i;
         int iAdj;
@@ -187,9 +187,9 @@ public class Hooke {
         stepLength = rho;
         iters      = 0;
 
-        if (objFunClsObj instanceof Rosenbrock) {
+        if (objFunCls.equals(Rosenbrock.class)) {
             fBefore = Rosenbrock.f(newX, nVars);
-        } else if (objFunClsObj instanceof Woods) {
+        } else if (objFunCls.equals(Woods.class)) {
             fBefore = Woods.f(newX, nVars);
         } else {
             fBefore = 0;
@@ -214,7 +214,7 @@ public class Hooke {
                 newX[i] = xBefore[i];
             }
 
-            newF = bestNearby(delta, newX, fBefore, nVars, objFunClsObj);
+            newF = bestNearby(delta, newX, fBefore, nVars, objFunCls);
 
             // If we made some improvements, pursue that direction.
             keep = 1;
@@ -238,7 +238,7 @@ public class Hooke {
 
                 fBefore = newF;
 
-                newF = bestNearby(delta, newX, fBefore, nVars, objFunClsObj);
+                newF = bestNearby(delta, newX, fBefore, nVars, objFunCls);
 
                 // If the further (optimistic) move was bad....
                 if (newF >= fBefore) {

--- a/nlp-unconstrained-core/hooke-jeeves/java/src/main/java/optimization/nonlinear/unconstrained/core/Rosenbrock.java
+++ b/nlp-unconstrained-core/hooke-jeeves/java/src/main/java/optimization/nonlinear/unconstrained/core/Rosenbrock.java
@@ -96,7 +96,7 @@ public final class Rosenbrock {
         Hooke h = new Hooke();
 
         jj = h.hooke(
-            nVars, startPt, endPt, rho, epsilon, iterMax, new Rosenbrock()
+            nVars, startPt, endPt, rho, epsilon, iterMax, Rosenbrock.class
         );
 
         System.out.println(

--- a/nlp-unconstrained-core/hooke-jeeves/java/src/main/java/optimization/nonlinear/unconstrained/core/Rosenbrock.java
+++ b/nlp-unconstrained-core/hooke-jeeves/java/src/main/java/optimization/nonlinear/unconstrained/core/Rosenbrock.java
@@ -49,7 +49,7 @@ public final class Rosenbrock {
      * (&quot;banana&quot;) function.
      *
      * @param x The point at which f(x) should be evaluated.
-     * @param n The number of coordinates of x.
+     * @param n The number of coordinates of <code>x</code>.
      *
      * @return The objective function value.
      */

--- a/nlp-unconstrained-core/hooke-jeeves/java/src/main/java/optimization/nonlinear/unconstrained/core/Woods.java
+++ b/nlp-unconstrained-core/hooke-jeeves/java/src/main/java/optimization/nonlinear/unconstrained/core/Woods.java
@@ -72,7 +72,7 @@ public final class Woods {
      * (TOMS algorithm 566).
      *
      * @param x The point at which f(x) should be evaluated.
-     * @param n The number of coordinates of x.
+     * @param n The number of coordinates of <code>x</code>.
      *
      * @return The objective function value.
      */

--- a/nlp-unconstrained-core/hooke-jeeves/java/src/main/java/optimization/nonlinear/unconstrained/core/Woods.java
+++ b/nlp-unconstrained-core/hooke-jeeves/java/src/main/java/optimization/nonlinear/unconstrained/core/Woods.java
@@ -132,7 +132,7 @@ public final class Woods {
         Hooke h = new Hooke();
 
         jj = h.hooke(
-            nVars, startPt, endPt, rho, epsilon, iterMax, new Woods()
+            nVars, startPt, endPt, rho, epsilon, iterMax, Woods.class
         );
 
         System.out.println(


### PR DESCRIPTION
1. Passing classes instead of objects &ndash; don't be doing unneeded memory allocations.
2. Marking out identifiers in Javadoc comments.
