### PR TITLE
NLPUC: Hooke-Jeeves-objc: Refactoring:

### DIFF
--- a/nlp-unconstrained-core/hooke-jeeves/objc/src/hooke.h
+++ b/nlp-unconstrained-core/hooke-jeeves/objc/src/hooke.h
@@ -11,13 +11,34 @@
  * ============================================================================
  */
 
+// (Not so dirty :-) hack: But we need double! Even on 32-bit systems.
+#define CGFLOAT_DEFINED 1
+typedef double          CGFloat;
+#define CGFLOAT_MIN     DBL_MIN
+#define CGFLOAT_MAX     DBL_MAX
+#define CGFLOAT_IS_DBL  1
+
 #import <Foundation/Foundation.h>
 
 /** Constant. The maximum number of variables. */
 extern const NSUInteger VARS;
 
+/** Constant. The stepsize geometric shrink. */
+extern const CGFloat RHO_BEGIN;
+
+/**
+ * Constant. The stepsize geometric shrink.
+ * <br />
+ * <br />The Hooke &amp; Jeeves algorithm works reasonably well
+ * on Rosenbrock's function, but can fare worse on some standard
+ * test functions, depending on rho. Here is an example that works well
+ * when rho = 0.5, but fares poorly with rho = 0.6, and better again
+ * with rho = 0.8.
+ */
+extern const CGFloat RHO_WOODS;
+
 /** Constant. The ending value of stepsize. */
-extern const NSUInteger EPSMIN;
+extern const CGFloat EPSMIN;
 
 /** Constant. The maximum number of iterations. */
 extern const NSUInteger IMAX;
@@ -27,6 +48,30 @@ extern const NSUInteger INDEX_ZERO;
 
 /** Helper constant. */
 extern const NSUInteger INDEX_ONE;
+
+/** Helper constant. */
+extern const NSUInteger INDEX_TWO;
+
+/** Helper constant. */
+extern const NSUInteger INDEX_THREE;
+
+/** Helper constant. */
+extern const NSUInteger TWO;
+
+/** Helper constant. */
+extern const NSUInteger FOUR;
+
+/** Helper constant. */
+extern const CGFloat MINUS_ONE_POINT_TWO;
+
+/** Helper constant. */
+extern const CGFloat ONE_POINT_ZERO;
+
+/** Helper constant. */
+extern const NSInteger MINUS_THREE;
+
+/** Helper constant. */
+extern const NSInteger MINUS_ONE;
 
 /** Helper constant. */
 extern const CGFloat ZERO_POINT_FIVE;

--- a/nlp-unconstrained-core/hooke-jeeves/objc/src/hooke.m
+++ b/nlp-unconstrained-core/hooke-jeeves/objc/src/hooke.m
@@ -22,8 +22,14 @@
 // Constant. The maximum number of variables.
 const NSUInteger VARS = 250;
 
+// Constant. The stepsize geometric shrink.
+const CGFloat RHO_BEGIN = 0.5;
+
+// Constant. The stepsize geometric shrink.
+const CGFloat RHO_WOODS = 0.6;
+
 // Constant. The ending value of stepsize.
-const NSUInteger EPSMIN = 1E-6;
+const CGFloat EPSMIN = 1E-6;
 
 // Constant. The maximum number of iterations.
 const NSUInteger IMAX = 5000;
@@ -33,6 +39,30 @@ const NSUInteger INDEX_ZERO = 0;
 
 // Helper constant.
 const NSUInteger INDEX_ONE = 1;
+
+// Helper constant.
+const NSUInteger INDEX_TWO = 2;
+
+// Helper constant.
+const NSUInteger INDEX_THREE = 3;
+
+// Helper constant.
+const NSUInteger TWO = 2;
+
+// Helper constant.
+const NSUInteger FOUR = 4;
+
+// Helper constant.
+const CGFloat MINUS_ONE_POINT_TWO = -1.2;
+
+// Helper constant.
+const CGFloat ONE_POINT_ZERO = 1.0;
+
+// Helper constant.
+const NSInteger MINUS_THREE = -3;
+
+// Helper constant.
+const NSInteger MINUS_ONE = -1;
 
 // Helper constant.
 const CGFloat ZERO_POINT_FIVE = 0.5;

--- a/nlp-unconstrained-core/hooke-jeeves/objc/src/rosenbrock.h
+++ b/nlp-unconstrained-core/hooke-jeeves/objc/src/rosenbrock.h
@@ -13,20 +13,8 @@
 
 #import "hooke.h"
 
-/** Constant. The stepsize geometric shrink. */
-extern const CGFloat RHO_BEGIN;
-
 /** Helper constant. */
 extern const CGFloat ONE_HUNDRED_POINT_ZERO;
-
-/** Helper constant. */
-extern const CGFloat ONE_POINT_ZERO;
-
-/** Helper constant. */
-extern const NSUInteger TWO;
-
-/** Helper constant. */
-extern const CGFloat MINUS_ONE_POINT_TWO;
 
 /**
  * The <code>Rosenbrock</code> class is responsible for solving a nonlinear

--- a/nlp-unconstrained-core/hooke-jeeves/objc/src/rosenbrock.m
+++ b/nlp-unconstrained-core/hooke-jeeves/objc/src/rosenbrock.m
@@ -13,20 +13,8 @@
 
 #import "rosenbrock.h"
 
-// Constant. The stepsize geometric shrink.
-const CGFloat RHO_BEGIN = 0.5;
-
 // Helper constant.
 const CGFloat ONE_HUNDRED_POINT_ZERO = 100.0;
-
-// Helper constant.
-const CGFloat ONE_POINT_ZERO = 1.0;
-
-// Helper constant.
-const NSUInteger TWO = 2;
-
-// Helper constant.
-const CGFloat MINUS_ONE_POINT_TWO = -1.2;
 
 // The Rosenbrock class.
 @implementation Rosenbrock

--- a/nlp-unconstrained-core/hooke-jeeves/objc/src/woods.h
+++ b/nlp-unconstrained-core/hooke-jeeves/objc/src/woods.h
@@ -13,23 +13,6 @@
 
 #import "hooke.h"
 
-/**
- * Constant. The stepsize geometric shrink.
- * <br />
- * <br />The Hooke &amp; Jeeves algorithm works reasonably well
- * on Rosenbrock's function, but can fare worse on some standard
- * test functions, depending on rho. Here is an example that works well
- * when rho = 0.5, but fares poorly with rho = 0.6, and better again
- * with rho = 0.8.
- */
-extern const CGFloat RHO_WOODS;
-
-/** Helper constant. */
-extern const NSUInteger INDEX_TWO;
-
-/** Helper constant. */
-extern const NSUInteger INDEX_THREE;
-
 /** Helper constant. */
 extern const NSUInteger ONE_HUNDRED;
 
@@ -41,15 +24,6 @@ extern const NSUInteger TEN;
 
 /** Helper constant. */
 extern const CGFloat TEN_POINT;
-
-/** Helper constant. */
-extern const NSUInteger FOUR;
-
-/** Helper constant. */
-extern const NSInteger MINUS_THREE;
-
-/** Helper constant. */
-extern const NSInteger MINUS_ONE;
 
 /**
  * The <code>Woods</code> class is responsible for solving a nonlinear

--- a/nlp-unconstrained-core/hooke-jeeves/objc/src/woods.m
+++ b/nlp-unconstrained-core/hooke-jeeves/objc/src/woods.m
@@ -13,15 +13,6 @@
 
 #import "woods.h"
 
-// Constant. The stepsize geometric shrink.
-const CGFloat RHO_WOODS = 0.6;
-
-// Helper constant.
-const NSUInteger INDEX_TWO = 2;
-
-// Helper constant.
-const NSUInteger INDEX_THREE = 3;
-
 // Helper constant.
 const NSUInteger ONE_HUNDRED = 100;
 
@@ -33,15 +24,6 @@ const NSUInteger TEN = 10;
 
 // Helper constant.
 const CGFloat TEN_POINT = 10.;
-
-// Helper constant.
-const NSUInteger FOUR = 4;
-
-// Helper constant.
-const NSInteger MINUS_THREE = -3;
-
-// Helper constant.
-const NSInteger MINUS_ONE = -1;
 
 // The Woods class.
 @implementation Woods


### PR DESCRIPTION
1. **EPSMIN** must be **double**, not int!
2. Declaring constants in those classes where they used first.
3. Hack against **GNUstep**: we need  **double** in any case, even on 32-bit systems.
