### PR TITLE
NLPUC: Hooke-Jeeves-cc: Refactoring:

### DIFF
--- a/nlp-unconstrained-core/hooke-jeeves/cc/src/hooke.cc
+++ b/nlp-unconstrained-core/hooke-jeeves/cc/src/hooke.cc
@@ -184,13 +184,16 @@ unsigned int Hooke::hooke(const unsigned int nVars,
         iters++;
         iAdj++;
 
-        std::printf(
-            "\nAfter %5d funevals, f(x) =  %.4le at\n",
-            fe->getFunEvals(), fBefore
-        );
+        std::cout << "\n" // Not using here std::endl -
+                          // see http://en.cppreference.com/w/cpp/io/manip/endl
+                          // for the reason why.
+                  << "After " << std::setw(5) << fe->getFunEvals()
+                  << " funevals, f(x) =  " << std::setprecision(4)
+                  << std::scientific << fBefore << " at\n";
 
         for (j = 0; j < nVars; j++) {
-            std::printf("   x[%2d] = %.4le\n", j, xBefore[j]);
+            std::cout << "   x[" << std::setw(2) << j << "] = " << xBefore[j]
+                      << "\n";
         }
 
         // Find best new point, one coord at a time.
@@ -314,14 +317,15 @@ int main(void) {
 
     jj = h->hooke(nVars, startPt, endPt, rho, epsilon, iterMax);
 
-    std::printf("\n\n\nHOOKE USED %d ITERATIONS, AND RETURNED\n", jj);
+    std::cout << "\n\n\nHOOKE USED " << jj << " ITERATIONS, AND RETURNED\n";
 
     for (i = 0; i < nVars; i++) {
-        std::printf("x[%3d] = %15.7le \n", i, endPt[i]);
+        std::cout << "x[" << std::setw(3) << i << "] = " << std::setw(15)
+                  << std::setprecision(7) << endPt[i] << " \n";
     }
 
 #ifdef WOODS
-    std::puts("True answer: f(1, 1, 1, 1) = 0.");
+    std::cout << "True answer: f(1, 1, 1, 1) = 0." << std::endl;
 #endif
 
     // Destructing the Hooke class instance.

--- a/nlp-unconstrained-core/hooke-jeeves/cc/src/hooke.cc
+++ b/nlp-unconstrained-core/hooke-jeeves/cc/src/hooke.cc
@@ -184,13 +184,13 @@ unsigned int Hooke::hooke(const unsigned int nVars,
         iters++;
         iAdj++;
 
-        printf(
+        std::printf(
             "\nAfter %5d funevals, f(x) =  %.4le at\n",
             fe->getFunEvals(), fBefore
         );
 
         for (j = 0; j < nVars; j++) {
-            printf("   x[%2d] = %.4le\n", j, xBefore[j]);
+            std::printf("   x[%2d] = %.4le\n", j, xBefore[j]);
         }
 
         // Find best new point, one coord at a time.
@@ -314,14 +314,14 @@ int main(void) {
 
     jj = h->hooke(nVars, startPt, endPt, rho, epsilon, iterMax);
 
-    printf("\n\n\nHOOKE USED %d ITERATIONS, AND RETURNED\n", jj);
+    std::printf("\n\n\nHOOKE USED %d ITERATIONS, AND RETURNED\n", jj);
 
     for (i = 0; i < nVars; i++) {
-        printf("x[%3d] = %15.7le \n", i, endPt[i]);
+        std::printf("x[%3d] = %15.7le \n", i, endPt[i]);
     }
 
 #ifdef WOODS
-    printf("True answer: f(1, 1, 1, 1) = 0.\n");
+    std::puts("True answer: f(1, 1, 1, 1) = 0.");
 #endif
 
     // Destructing the Hooke class instance.

--- a/nlp-unconstrained-core/hooke-jeeves/cc/src/hooke.cc
+++ b/nlp-unconstrained-core/hooke-jeeves/cc/src/hooke.cc
@@ -154,7 +154,7 @@ unsigned int Hooke::hooke(const unsigned int nVars,
     for (i = 0; i < nVars; i++) {
         newX[i] = xBefore[i] = startPt[i];
 
-        delta[i] = fabs(startPt[i] * rho);
+        delta[i] = std::fabs(startPt[i] * rho);
 
         if (delta[i] == 0.0) {
             delta[i] = rho;
@@ -209,9 +209,9 @@ unsigned int Hooke::hooke(const unsigned int nVars,
             for (i = 0; i < nVars; i++) {
                 // Firstly, arrange the sign of delta[].
                 if (newX[i] <= xBefore[i]) {
-                    delta[i] = 0.0 - fabs(delta[i]);
+                    delta[i] = 0.0 - std::fabs(delta[i]);
                 } else {
-                    delta[i] = fabs(delta[i]);
+                    delta[i] = std::fabs(delta[i]);
                 }
 
                 // Now, move further in this direction.
@@ -239,8 +239,8 @@ unsigned int Hooke::hooke(const unsigned int nVars,
             for (i = 0; i < nVars; i++) {
                 keep = 1;
 
-                if (fabs(newX[i] - xBefore[i])
-                    > (ZERO_POINT_FIVE * fabs(delta[i]))) {
+                if (std::fabs(newX[i] - xBefore[i])
+                    > (ZERO_POINT_FIVE * std::fabs(delta[i]))) {
 
                     break;
                 } else {

--- a/nlp-unconstrained-core/hooke-jeeves/cc/src/hooke.h
+++ b/nlp-unconstrained-core/hooke-jeeves/cc/src/hooke.h
@@ -12,8 +12,9 @@
  */
 
 #include <cstdlib>
+#include <iostream>
+#include <iomanip>
 #include <cmath>
-#include <cstdio>
 
 /**
  * The <code>NLPUCCoreHooke</code> namespace is used as a container


### PR DESCRIPTION
1. Adding **std::** namespace prefix to the standard C-style output library calls.
2. Adding **std::** namespace prefix to the standard numerics library calls.
3. Replacing standard C-style output library calls with their counterparts from the stream-based I/O class library.
