### PR TITLE
NLPUC: Nelder-Mead-c: Fix alg porting and refactoring:

### DIFF
--- a/nlp-unconstrained-core/nelder-mead/c/src/nelmin.c
+++ b/nlp-unconstrained-core/nelder-mead/c/src/nelmin.c
@@ -144,7 +144,7 @@ struct optimum *nelmin(const unsigned int  n,
      * to be replaced.
      */
     ylo = y[0];
-    ilo = 1;
+    ilo = 0;
 
     for (i = 1; i < nn; i++) {
         if (y[i] < ylo) {
@@ -156,7 +156,7 @@ struct optimum *nelmin(const unsigned int  n,
     L2000:;
 
     ynewlo = y[0];
-    ihi    = 1;
+    ihi    = 0;
 
     for (i = 1; i < nn; i++) {
         if (ynewlo < y[i]) {
@@ -258,7 +258,7 @@ struct optimum *nelmin(const unsigned int  n,
                 }
 
                 ylo = y[0];
-                ilo = 1;
+                ilo = 0;
 
                 for (i = 1; i < nn; i++) {
                     if (y[i] < ylo) {

--- a/nlp-unconstrained-core/nelder-mead/c/src/nelmin.c
+++ b/nlp-unconstrained-core/nelder-mead/c/src/nelmin.c
@@ -18,8 +18,7 @@
 #endif
 
 /* Main optimization function nelmin(...). */
-struct optimum *nelmin(      double      (*f)(const double *),
-                       const unsigned int  n,
+struct optimum *nelmin(const unsigned int  n,
                              double       *start,
                        const double        reqmin,
                        const double       *step,
@@ -473,7 +472,7 @@ int main(void) {
 
     printf("\n  F(X) = %14.6E\n", ynewlo);
 
-    opt = nelmin(f, n, start, reqmin, step, konvge, kcount);
+    opt = nelmin(n, start, reqmin, step, konvge, kcount);
 
     for (i = 0; i < n; i++) {
         xmin[i] = opt->xmin[i];

--- a/nlp-unconstrained-core/nelder-mead/c/src/nelmin.c
+++ b/nlp-unconstrained-core/nelder-mead/c/src/nelmin.c
@@ -22,7 +22,7 @@ struct optimum *nelmin(const unsigned int  n,
                              double       *start,
                        const double        reqmin,
                        const double       *step,
-                       const          int  konvge,
+                       const unsigned int  konvge,
                        const unsigned int  kcount) {
 
     struct optimum *opt; /* The structure to hold the optimum data          */

--- a/nlp-unconstrained-core/nelder-mead/c/src/nelmin.c
+++ b/nlp-unconstrained-core/nelder-mead/c/src/nelmin.c
@@ -69,38 +69,38 @@ struct optimum *nelmin(const unsigned int  n,
 
     opt->ynewlo = icount = numres = 0;
 
-    opt->indics[0] = icount;
-    opt->indics[1] = numres;
+    opt->indics[INDEX_0] = icount;
+    opt->indics[INDEX_1] = numres;
 
     /* Check the input parameters. */
     if (reqmin <= 0) {
-        ifault = 1;
+        ifault = IFAULT_1;
 
-        opt->indics[2] = ifault;
+        opt->indics[INDEX_2] = ifault;
 
         return (opt);
     }
 
     if (n < 1) {
-        ifault = 1;
+        ifault = IFAULT_1;
 
-        opt->indics[2] = ifault;
+        opt->indics[INDEX_2] = ifault;
 
         return (opt);
     }
 
     if (VARS < n) {
-        ifault = 1;
+        ifault = IFAULT_1;
 
-        opt->indics[2] = ifault;
+        opt->indics[INDEX_2] = ifault;
 
         return (opt);
     }
 
     if (konvge < 1) {
-        ifault = 1;
+        ifault = IFAULT_1;
 
-        opt->indics[2] = ifault;
+        opt->indics[INDEX_2] = ifault;
 
         return (opt);
     }
@@ -143,8 +143,8 @@ struct optimum *nelmin(const unsigned int  n,
      * ynewlo = y[ihi] indicates the vertex of the simplex
      * to be replaced.
      */
-    ylo = y[0];
-    ilo = 0;
+    ylo = y[INDEX_0];
+    ilo =   INDEX_0;
 
     for (i = 1; i < nn; i++) {
         if (y[i] < ylo) {
@@ -155,8 +155,8 @@ struct optimum *nelmin(const unsigned int  n,
 
     L2000:;
 
-    ynewlo = y[0];
-    ihi    = 0;
+    ynewlo = y[INDEX_0];
+    ihi    =   INDEX_0;
 
     for (i = 1; i < nn; i++) {
         if (ynewlo < y[i]) {
@@ -257,8 +257,8 @@ struct optimum *nelmin(const unsigned int  n,
                     goto L3000;
                 }
 
-                ylo = y[0];
-                ilo = 0;
+                ylo = y[INDEX_0];
+                ilo =   INDEX_0;
 
                 for (i = 1; i < nn; i++) {
                     if (y[i] < ylo) {
@@ -328,7 +328,7 @@ struct optimum *nelmin(const unsigned int  n,
         z = 0;
 
         for (i = 0; i < nn; i++) {
-            z += pow((y[i] - x), 2);
+            z += pow((y[i] - x), SQUARE);
         }
 
         if (rq < z) {
@@ -346,7 +346,7 @@ L3000:;
     ynewlo = y[ilo];
 
     if (kcount < icount) {
-        ifault = 2;
+        ifault = IFAULT_2;
 
         for (i = 0; i < n; i++) {
             opt->xmin[i] = xmin[i];
@@ -354,17 +354,17 @@ L3000:;
 
         opt->ynewlo = ynewlo;
 
-        opt->indics[0] = icount;
-        opt->indics[1] = numres;
-        opt->indics[2] = ifault;
+        opt->indics[INDEX_0] = icount;
+        opt->indics[INDEX_1] = numres;
+        opt->indics[INDEX_2] = ifault;
 
         return (opt);
     }
 
-    ifault = 0;
+    ifault = IFAULT_0;
 
     for (i = 0; i < n; i++) {
-        del     = step[i] * EPS;
+        del      = step[i] * EPS;
         xmin[i] += del;
 
         z = f(xmin);
@@ -372,7 +372,7 @@ L3000:;
         icount++;
 
         if (z < ynewlo) {
-            ifault = 2;
+            ifault = IFAULT_2;
 
             goto L4000;
         }
@@ -384,7 +384,7 @@ L3000:;
         icount++;
 
         if (z < ynewlo) {
-            ifault = 2;
+            ifault = IFAULT_2;
 
             goto L4000;
         }
@@ -401,9 +401,9 @@ L4000:;
 
         opt->ynewlo = ynewlo;
 
-        opt->indics[0] = icount;
-        opt->indics[1] = numres;
-        opt->indics[2] = ifault;
+        opt->indics[INDEX_0] = icount;
+        opt->indics[INDEX_1] = numres;
+        opt->indics[INDEX_2] = ifault;
 
         return (opt);
     }
@@ -442,25 +442,25 @@ int main(void) {
     /* Starting guess for Rosenbrock's test function. */
     puts("\nTEST01\n  Apply NELMIN to ROSENBROCK function.");
 
-    n        =  2;
-    start[0] = -1.2;
-    start[1] =  1;
+    n              = ROSEN_GUESS_N;
+    start[INDEX_0] = ROSEN_GUESS_1;
+    start[INDEX_1] = ROSEN_GUESS_2;
 #else
     /* Starting guess test problem "Woods". */
     puts("\nTEST05\n  Apply NELMIN to WOODS function.");
 
-    n        =  4;
-    start[0] = -3;
-    start[1] = -1;
-    start[2] = -3;
-    start[3] = -1;
+    n              = WOODS_GUESS_N;
+    start[INDEX_0] = WOODS_GUESS_1;
+    start[INDEX_1] = WOODS_GUESS_2;
+    start[INDEX_2] = WOODS_GUESS_1;
+    start[INDEX_3] = WOODS_GUESS_2;
 #endif
 
-    reqmin  = 1e-08;
-    step[0] = 1;
-    step[1] = 1;
-    konvge  = 10;
-    kcount  = 500;
+    reqmin        = REQMIN_GUESS;
+    step[INDEX_0] = STEP_GUESS_1;
+    step[INDEX_1] = STEP_GUESS_2;
+    konvge        = KONVGE_GUESS;
+    kcount        = KCOUNT_GUESS;
 
     puts(  "\n  Starting point X:\n");
 
@@ -480,9 +480,9 @@ int main(void) {
 
     ynewlo = opt->ynewlo;
 
-    icount = opt->indics[0];
-    numres = opt->indics[1];
-    ifault = opt->indics[2];
+    icount = opt->indics[INDEX_0];
+    numres = opt->indics[INDEX_1];
+    ifault = opt->indics[INDEX_2];
 
     free(opt);
 

--- a/nlp-unconstrained-core/nelder-mead/c/src/nelmin.c
+++ b/nlp-unconstrained-core/nelder-mead/c/src/nelmin.c
@@ -73,7 +73,7 @@ struct optimum *nelmin(const unsigned int  n,
     opt->indics[1] = numres;
 
     /* Check the input parameters. */
-    if (reqmin <= 0.0E+00) {
+    if (reqmin <= 0) {
         ifault = 1;
 
         opt->indics[2] = ifault;
@@ -109,7 +109,7 @@ struct optimum *nelmin(const unsigned int  n,
     dn     = n;
     nn     = n + 1;
     dnn    = nn;
-    del    = 1.0E+00;
+    del    = 1;
     rq     = reqmin * dn;
 
     /* Construction of initial simplex. */
@@ -170,7 +170,7 @@ struct optimum *nelmin(const unsigned int  n,
      * excepting the vertex with y value ynewlo.
      */
     for (i = 0; i < n; i++) {
-        z = 0.0E+00;
+        z = 0;
 
         for (j = 0; j < nn; j++) {
             z += p[i][j];
@@ -244,7 +244,7 @@ struct optimum *nelmin(const unsigned int  n,
             if (y[ihi] < y2star) {
                 for (j = 0; j < nn; j++) {
                     for (i = 0; i < n; i++) {
-                        p[i][j] = (p[i][j] + p[i][ilo]) * 0.5E+00;
+                        p[i][j] = (p[i][j] + p[i][ilo]) * CCOEFF;
                         xmin[i] =  p[i][j];
                     }
 
@@ -318,14 +318,14 @@ struct optimum *nelmin(const unsigned int  n,
     /* Check to see if minimum reached. */
     if (icount <= kcount) {
         jcount = konvge;
-        z      = 0.0E+00;
+        z      = 0;
 
         for (i = 0; i < nn; i++) {
             z += y[i];
         }
 
         x = z / dnn;
-        z = 0.0E+00;
+        z = 0;
 
         for (i = 0; i < nn; i++) {
             z += pow((y[i] - x), 2);
@@ -444,21 +444,21 @@ int main(void) {
 
     n        =  2;
     start[0] = -1.2;
-    start[1] =  1.0;
+    start[1] =  1;
 #else
     /* Starting guess test problem "Woods". */
     puts("\nTEST05\n  Apply NELMIN to WOODS function.");
 
     n        =  4;
-    start[0] = -3.0;
-    start[1] = -1.0;
-    start[2] = -3.0;
-    start[3] = -1.0;
+    start[0] = -3;
+    start[1] = -1;
+    start[2] = -3;
+    start[3] = -1;
 #endif
 
-    reqmin  = 1.0E-08;
-    step[0] = 1.0;
-    step[1] = 1.0;
+    reqmin  = 1e-08;
+    step[0] = 1;
+    step[1] = 1;
     konvge  = 10;
     kcount  = 500;
 

--- a/nlp-unconstrained-core/nelder-mead/c/src/nelmin.h
+++ b/nlp-unconstrained-core/nelder-mead/c/src/nelmin.h
@@ -43,6 +43,34 @@
 /** Constant. The optimality factor. */
 #define EPS .001
 
+/** Helper constants. */
+#define INDICS_N       3
+
+#define INDEX_0        0
+#define INDEX_1        1
+#define INDEX_2        2
+#define INDEX_3        3
+
+#define IFAULT_0       0
+#define IFAULT_1       1
+#define IFAULT_2       2
+
+#define SQUARE         2
+
+#define ROSEN_GUESS_N  2
+#define ROSEN_GUESS_1 -1.2
+#define ROSEN_GUESS_2  1
+
+#define WOODS_GUESS_N  4
+#define WOODS_GUESS_1 -3
+#define WOODS_GUESS_2 -1
+
+#define REQMIN_GUESS   1e-8
+#define STEP_GUESS_1   1
+#define STEP_GUESS_2   1
+#define KONVGE_GUESS   10
+#define KCOUNT_GUESS   500
+
 /**
  * The structure to hold the optimum data (and metadata)
  * as the result of performing the optimization procedure.
@@ -64,7 +92,7 @@ struct optimum {
      *     <li>The number of restarts (<code>numres</code>).</li>
      *     <li>The error indicator    (<code>ifault</code>).</li></ul>
      */
-    unsigned int indics[3];
+    unsigned int indics[INDICS_N];
 };
 
 /**

--- a/nlp-unconstrained-core/nelder-mead/c/src/nelmin.h
+++ b/nlp-unconstrained-core/nelder-mead/c/src/nelmin.h
@@ -86,7 +86,7 @@ extern struct optimum *nelmin(const unsigned int,
                                     double *,
                               const double,
                               const double *,
-                              const          int,
+                              const unsigned int,
                               const unsigned int);
 
 #endif /* __C__NELMIN_H */

--- a/nlp-unconstrained-core/nelder-mead/c/src/nelmin.h
+++ b/nlp-unconstrained-core/nelder-mead/c/src/nelmin.h
@@ -72,7 +72,6 @@ struct optimum {
  * <br />
  * <br />The nelmin subroutine itself (Nelder-Mead minimization).
  *
- * @param f      The objective function f(x).
  * @param n      The number of variables.
  * @param start  The starting point for the iteration.
  * @param reqmin The terminating limit for the variance of function values.
@@ -83,8 +82,7 @@ struct optimum {
  * @return The structure to hold the optimum data (and metadata)
  *         as the result of performing the optimization procedure.
  */
-extern struct optimum *nelmin(      double (*)(const double *),
-                              const unsigned int,
+extern struct optimum *nelmin(const unsigned int,
                                     double *,
                               const double,
                               const double *,

--- a/nlp-unconstrained-core/nelder-mead/c/src/nelmin.h
+++ b/nlp-unconstrained-core/nelder-mead/c/src/nelmin.h
@@ -32,16 +32,16 @@
 #define VARS 20
 
 /** Constant. The reflection coefficient. */
-#define RCOEFF 1.0E+00
+#define RCOEFF 1
 
 /** Constant. The extension coefficient. */
-#define ECOEFF 2.0E+00
+#define ECOEFF 2
 
 /** Constant. The contraction coefficient. */
-#define CCOEFF 0.5E+00
+#define CCOEFF .5
 
 /** Constant. The optimality factor. */
-#define EPS 0.001E+00
+#define EPS .001
 
 /**
  * The structure to hold the optimum data (and metadata)

--- a/nlp-unconstrained-core/nelder-mead/c/src/rosenbrock.c
+++ b/nlp-unconstrained-core/nelder-mead/c/src/rosenbrock.c
@@ -18,10 +18,10 @@ double f(const double *x) {
     double a;
     double b;
 
-    a = x[1] - pow(x[0], 2);
-    b = 1    -     x[0];
+    a = ACOEFF     -     x[INDEX_0];
+    b = x[INDEX_1] - pow(x[INDEX_0], SQUARE);
 
-    return (100 * pow(a, 2) + pow(b, 2));
+    return (pow(a, SQUARE) + BCOEFF * pow(b, SQUARE));
 }
 
 /* ========================================================================= */

--- a/nlp-unconstrained-core/nelder-mead/c/src/rosenbrock.h
+++ b/nlp-unconstrained-core/nelder-mead/c/src/rosenbrock.h
@@ -29,6 +29,10 @@
 
 #include "nelmin.h"
 
+/** Helper constants. */
+#define ACOEFF 1
+#define BCOEFF 100
+
 /**
  * The user-supplied objective function f(x).
  * <br />

--- a/nlp-unconstrained-core/nelder-mead/c/src/woods.c
+++ b/nlp-unconstrained-core/nelder-mead/c/src/woods.c
@@ -24,20 +24,20 @@ double f(const double *x) {
     double t4;
     double t5;
 
-    s1 = x[1] - pow(x[0], 2);
-    s2 = 1    -     x[0];
-    s3 = x[1] -     1;
+    s1 = x[INDEX_1] - pow(x[INDEX_0], SQUARE);
+    s2 = ACOEFF     -     x[INDEX_0];
+    s3 = x[INDEX_1] -     ACOEFF;
 
-    t1 = x[3] - pow(x[2], 2);
-    t2 = 1    -     x[2];
-    t3 = x[3] -     1;
+    t1 = x[INDEX_3] - pow(x[INDEX_2], SQUARE);
+    t2 = ACOEFF     -     x[INDEX_2];
+    t3 = x[INDEX_3] -     ACOEFF;
 
     t4 = s3 + t3;
     t5 = s3 - t3;
 
-    return (100 * pow(s1, 2) + pow(s2, 2)
-           + 90 * pow(t1, 2) + pow(t2, 2)
-           + 10 * pow(t4, 2) + pow(t5, 2) / 10);
+    return (SCOEFF * pow(s1, SQUARE) + pow(s2, SQUARE)
+          + TCOEFF * pow(t1, SQUARE) + pow(t2, SQUARE)
+          + DCOEFF * pow(t4, SQUARE) + pow(t5, SQUARE) / DCOEFF);
 }
 
 /* ========================================================================= */

--- a/nlp-unconstrained-core/nelder-mead/c/src/woods.h
+++ b/nlp-unconstrained-core/nelder-mead/c/src/woods.h
@@ -29,6 +29,12 @@
 
 #include "nelmin.h"
 
+/** Helper constants. */
+#define ACOEFF 1
+#define SCOEFF 100
+#define TCOEFF 90
+#define DCOEFF 10
+
 /**
  * The user-supplied objective function f(x).
  * <br />


### PR DESCRIPTION
1. There's no need to pass objective function as a parameter &ndash; we have its prototype declaration.
2. Artificial array indices must begin at zero.
3. All integer variables are to be unsigned.
4. The compiler will take care about casting and widening (int -> double).
5. Get rid of magic numbers: introduce helper constants for that.
